### PR TITLE
Allow configuring CSRF_TRUSTED_ORIGINS via env

### DIFF
--- a/src/app/settings/common.py
+++ b/src/app/settings/common.py
@@ -56,6 +56,11 @@ if 'DJANGO_ALLOWED_HOSTS' in os.environ:
     ALLOWED_HOSTS = os.environ['DJANGO_ALLOWED_HOSTS'].split(',')
 else:
     ALLOWED_HOSTS = []
+    
+if 'DJANGO_CSRF_TRUSTED_ORIGINS' in os.environ:
+    CSRF_TRUSTED_ORIGINS = os.environ['CSRF_TRUSTED_ORIGINS'].split(',')
+else:
+    CSRF_TRUSTED_ORIGINS = []
 
 INTERNAL_IPS = ['127.0.0.1',]
 


### PR DESCRIPTION
New env var `DJANGO_CSRF_TRUSTED_ORIGINS` to allow configuring CSRF_TRUSTED_ORIGINS. This allows for example `setTraits` to be called from localhost in development